### PR TITLE
fix anonymous upload settings

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -79,7 +79,7 @@
                     );
 
                     array_push($config_lines, 
-                        "define('__ANONYMOUS_UPLOAD', '" . ($info['enableanonymous'] === null?"false":"true") . "');"
+                        "define('__ANONYMOUS_UPLOAD', " . ($info['enableanonymous'] === null?"false":"true") . ");"
                     );
                     
                     $htaccess = array(


### PR DESCRIPTION
Because a value of `defain('__ANONYMOUS_UPLOAD)` is quoted single quotation mark, `__ANONYMOUS_UPLOAD` doesn't work.